### PR TITLE
Fix : Visibility of Adopt me text in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,6 @@
               <a
                 href="#meet"
                 class="lg:p-3 text-custom-heading font-bold hover:underline underline-offset-4 turn-red-hover navbar-item"
-                style=""
                 >Meet Pets</a
               >
             </li>
@@ -327,7 +326,9 @@
                 </li>
               </ul>
               <a class="self-center pt-2" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -376,7 +377,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -431,7 +434,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -484,7 +489,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -539,7 +546,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -592,7 +601,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button></a
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button></a
               >
             </div>
           </div>
@@ -647,7 +658,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button>
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button>
               </a>
             </div>
           </div>
@@ -700,7 +713,9 @@
                 </li>
               </ul>
               <a class="self-center" href="adopt.html">
-                <button type="button" class="hover-button">Adopt me</button>
+                <button type="button" class="hover-button text_5">
+                  Adopt me
+                </button>
               </a>
             </div>
           </div>

--- a/light-dark-theme.js
+++ b/light-dark-theme.js
@@ -51,6 +51,7 @@ let t3 = new element(
   "text-white"
 );
 let t4 = new element(["text_4"], "text-choco", "text-white");
+let t5 = new element(["text_5"], "text-gray-900", "text-white");
 
 // let b1 = new element("bg_1", "bg-slate-50", "bg-slate-400");
 let b1 = new element(
@@ -83,6 +84,7 @@ toggler.addEventListener("click", () => {
   t2.toggle();
   t3.toggle();
   t4.toggle();
+  t5.toggle();
   b1.toggle();
   b2.toggle();
   b3.toggle();

--- a/style.css
+++ b/style.css
@@ -158,7 +158,7 @@
   font-size: 1.7rem;
   border-radius: 0.5rem;
   border: 0.2rem solid rgb(99, 99, 99);
-  color: #fff;
+  color: black;
   cursor: pointer;
   background: #ffc82c;
   transition: background-color 0.3s ease, color 0.3s ease;


### PR DESCRIPTION
Description
In Light mode, the visibility of text adopt me is not clear when the button is not hovered.
Before
![Visibility](https://github.com/JoyelJohny/PetMe/assets/81413791/582c3909-899d-4169-b7fc-64355e9b1e1f)
After
![a_visibility](https://github.com/JoyelJohny/PetMe/assets/81413791/730bda25-1893-467a-8b75-18eba08d830c)
